### PR TITLE
Fix server route for chat widget

### DIFF
--- a/widget-chat/index.html
+++ b/widget-chat/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Widget Chat Demo</title>
+  <link rel="stylesheet" href="widget-chat.css">
+</head>
+<body>
+  <h1>Widget Chat Demo</h1>
+  <p>Se você está vendo esta página, o servidor do widget está ativo.</p>
+  <script src="widget-chat.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add missing demo `index.html` for chat widget server

## Testing
- `node server.js` started the server and returned the HTML page
- `curl http://localhost:9092/ | head`

------
https://chatgpt.com/codex/tasks/task_e_68498411fbb08333b758315cfe3f9cb6