### PR TITLE
Fix server path for landing page

### DIFF
--- a/widget-chat/server.js
+++ b/widget-chat/server.js
@@ -7,11 +7,12 @@ const app = express();
 // Configuração do CORS para permitir todas as origens
 app.use(cors());
 app.use(express.json());
-app.use(express.static(path.join(__dirname)));
+// Servir arquivos estáticos a partir da raiz do projeto
+app.use(express.static(path.join(__dirname, '..')));
 
-// Rota para a página principal
+// Rota para a página principal da landing page
 app.get('/', (req, res) => {
-  res.sendFile(path.join(__dirname, 'index.html'));
+  res.sendFile(path.join(__dirname, '..', 'index.html'));
 });
 
 // Rota proxy para o webhook do n8n


### PR DESCRIPTION
## Summary
- serve static files from project root in server.js
- return the main index.html from the root

## Testing
- `npm install` inside widget-chat
- `node widget-chat/server.js` and `curl http://localhost:9092/`

------
https://chatgpt.com/codex/tasks/task_e_68498d350be08333a3ac5f19c3dea5ae